### PR TITLE
Avoid AttributeError in Semantic Kernel plan execution

### DIFF
--- a/src/copilot_semantickernel/chat.py
+++ b/src/copilot_semantickernel/chat.py
@@ -46,7 +46,7 @@ async def chat_completion(messages: list[dict], stream: bool = False,
     # Create and run plan based on the customer ask
     planner = StepwisePlanner(kernel, config=StepwisePlannerConfig(max_iterations=5))
     plan = planner.create_plan(ask)
-    result = await kernel.run_async(plan)
+    result = await plan.invoke_async()
 
     # limit size of returned context
     context = customer_support_plugin.context


### PR DESCRIPTION
Fix for #62 

When executing the copilot sample with semantic kernel implementation, plan execution always seems to encounter an error, [when the kernel attempts to generate a description for the function](
https://github.com/microsoft/semantic-kernel/blob/main/python/semantic_kernel/kernel.py#L308). The result from the plan execution includes `last_error_description:
"'NoneType' object has no attribute 'describe'"`.

This can be circumvented by executing the plan with `plan.invoke_async()` as opposed to `kernel.run_async(plan)`.